### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Available on Cloud9 IDE: http://c9.io/sabind/ruby-learn-2-code
 
 RUBY Version: ruby 2.1.1p76 (this is limited by what cloud9 IDE includes on its servers)
 
-We're going to be creating various coding challanges and answers.
+We're going to be creating various coding challenges and answers.
 
 Running 'rspec' from the command line will execute the tests. Reading through the
 failures will give you an idea of what to code. 


### PR DESCRIPTION
@sabind, I've corrected a typographical error in the documentation of the [learn-2-code-ruby](https://github.com/sabind/learn-2-code-ruby) project. Specifically, I've changed challange to challenge. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
